### PR TITLE
Crud-actions visible on smaller screens

### DIFF
--- a/src/VuetifyResource.vue
+++ b/src/VuetifyResource.vue
@@ -820,7 +820,7 @@
             display: none;
         }
 
-        .vuetify-resource td:first-child, .vuetify-resource td:nth-child(2)
+        .vuetify-resource td:first-child, .vuetify-resource td:nth-child(2), .vuetify-resource td.crud-actions
         {
             display: table-cell;
         }


### PR DESCRIPTION
The crud-actions will always be displayed, even for mobile. Earlier the crud-actions would just disappear, because the screen is to small. The crud-actions should be always visible.