### PR TITLE
Removed default width on first child of thead

### DIFF
--- a/src/VuetifyResource.vue
+++ b/src/VuetifyResource.vue
@@ -757,11 +757,6 @@
         position: relative;
     }
 
-    .vuetify-resource th:first-child
-    {
-        width: 40px;
-    }
-
     td.crud-actions
     {
         display: flex;


### PR DESCRIPTION
The default width on the first row overwrite the vuetify propeties. So I never could use the prop width on a datatable