### PR TITLE
use columntype as string and as component  fixes #42

### DIFF
--- a/src/VuetifyResource.vue
+++ b/src/VuetifyResource.vue
@@ -160,10 +160,8 @@
                         <td v-for="item in tableContent">
                             <component
                                 :content="props.item[item.value]"
-                                :is="item.columnType"
-                                v-if="typeof item.columnType === 'object'"
+                                :is="getColumnType(item.columnType)"
                             ></component>
-                            <span v-if="typeof item.columnType !== 'object'">{{ props.item[item.value] }}</span>
                         </td>
                         <td class="crud-actions">
                             <v-tooltip left v-if="canUpdate === true">
@@ -216,6 +214,8 @@
 <script>
     import texts from './texts.js';
     import ActivityOverlay from './components/ActivityOverlay.vue';
+    import Text from './columnTypes/Text.vue';
+    import Checkbox from './columnTypes/Checkbox.vue';
 
     export default {
         name: 'vuetify-resource',
@@ -388,7 +388,7 @@
              *                  align:      string
              *                  sortable:   coolean
              *                  value:      string
-             *                  columnType: object/component
+             *                  columnType: object/component or string
              *              }
              */
             tableContent: {required: true, type: Array},
@@ -721,6 +721,21 @@
                         }
                     });
                 }
+            },
+
+            getColumnType(columnType) {
+                if (typeof columnType === 'object') {
+                    return columnType;
+                } else if(typeof columnType === 'string') {
+                    switch (columnType.toLowerCase()) {
+                        case 'checkbox':
+                            return Checkbox;
+                        default:
+                        case 'text':
+                            return Text;
+                    }
+                }
+                return Text;
             },
 
             /**

--- a/src/columnTypes/Checkbox.vue
+++ b/src/columnTypes/Checkbox.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="column type-checkbox">
-        <i class="material-icons icon icon--selection-control icon--checkbox">{{isTrue() ? 'check_circle' : ''}}</i>
+        <v-icon>{{isTrue() ? $vuetify.icons.checkboxOn : ''}}</v-icon>
     </div>
 </template>
 


### PR DESCRIPTION
Columntypes are working again and you dont need to require/include the defaults it's now available via a string