### PR TITLE
Fix footer props

### DIFF
--- a/src/VuetifyResource.vue
+++ b/src/VuetifyResource.vue
@@ -154,6 +154,9 @@
                     :items-per-page-options="rowsPerPageItems"
                     :show-select="useCheckboxes"
                     :server-items-length="totalItems"
+                    :footer-props="{
+                        items-per-page-options: rowsPerPageItems
+                    }"
                     class="elevation-1"
                     item-key="id"
                     v-model="selected"

--- a/src/VuetifyResource.vue
+++ b/src/VuetifyResource.vue
@@ -151,7 +151,6 @@
                     :items="items"
                     :loading="loading"
                     :options.sync="pagination"
-                    :items-per-page-options="rowsPerPageItems"
                     :show-select="useCheckboxes"
                     :server-items-length="totalItems"
                     :footer-props="{


### PR DESCRIPTION
Properties were not being passed now to the footer, making the `items-per-age-options` being passed useless.